### PR TITLE
Family Member Home Page + Moving Employee List page around

### DIFF
--- a/authentication/login.php
+++ b/authentication/login.php
@@ -59,7 +59,7 @@ switch ($_SESSION['access']) {
     header("Location: http://$host$uri/$extra");
     break;
   case 6:
-    $extra = "../employee/familymember-home.php";
+    $extra = "../patient/family-member-home.php";
     header("Location: http://$host$uri/$extra");
     break;
   }

--- a/employee/employee-list.php
+++ b/employee/employee-list.php
@@ -21,9 +21,39 @@ echo <<<EOT
 </form>
 EOT;
 
-// table + headings
+// create the rest of the page
 echo <<<EOT
 <h1>Employees</h1>
+
+
+<form action="employee-list.php" method="post">
+<label for="empId">Employee ID:</label>
+<input type="text" name="empId">
+EOT;
+
+// only admins can change salary values, supervisors can't.
+if ($_SESSION['access'] == 1) {
+  echo <<<EOT
+  <label for="salary">Salary:</label>
+  <input type="text" name="salary">
+
+  <input type="submit">
+  <input type="reset" value="Cancel">
+  </form>
+  EOT;
+} else {
+  echo <<<EOT
+  <label for="salary">Salary:</label>
+  <input type="text" name="salary" disabled>
+
+  <input type="submit" value="Ok">
+  <input type="reset" value="Cancel">
+  </form>
+  EOT;
+}
+
+// table + headings
+echo <<<EOT
 
 <table>
 <thead>
@@ -37,52 +67,22 @@ echo <<<EOT
 <tbody>
 EOT;
 
-// query for all employees
-if ($stmt = $mysqli->prepare("SELECT employeeId, firstName, lastName, role, salary FROM users INNER JOIN employees ON users.id = employees.userId INNER JOIN roles ON users.roleId = roles.roleId;")) {
-  $stmt->execute();
-  $stmt->bind_result($employeeId, $firstName, $lastName, $role, $salary);
-  // fetch values
-    while ($stmt->fetch()) {
-        printf (<<<EOT
-        <tr>
-          <td>%s</td>
-          <td>%s</td>
-          <td>%s</td>
-          <td>%s</td>
-        </tr>
-        EOT, $employeeId, $firstName . " " . $lastName, $role, $salary);
-  }
-  // create the rest of the page
-  echo <<<EOT
-    </tbody>
-  </table>
-
-  <form action="employee-list.php" method="post">
-  <label for="empId">Employee ID:</label>
-  <input type="text" name="empId">
-  EOT;
-
-  // only admins can change salary values, supervisors can't.
-  if ($_SESSION['access'] == 1) {
-    echo <<<EOT
-    <label for="salary">Salary:</label>
-    <input type="text" name="salary">
-
-    <input type="submit">
-    <input type="reset" value="Cancel">
-    </form>
-    EOT;
-  } else {
-    echo <<<EOT
-    <label for="salary">Salary:</label>
-    <input type="text" name="salary" disabled>
-
-    <input type="submit" value="Ok">
-    <input type="reset" value="Cancel">
-    </form>
-    EOT;
-  }
-  $stmt->close();
+  // query for all employees
+  if ($stmt = $mysqli->prepare("SELECT employeeId, firstName, lastName, role, salary FROM users INNER JOIN employees ON users.id = employees.userId INNER JOIN roles ON users.roleId = roles.roleId;")) {
+    $stmt->execute();
+    $stmt->bind_result($employeeId, $firstName, $lastName, $role, $salary);
+    // fetch values
+      while ($stmt->fetch()) {
+          printf (<<<EOT
+          <tr>
+            <td>%s</td>
+            <td>%s</td>
+            <td>%s</td>
+            <td>%s</td>
+          </tr>
+          EOT, $employeeId, $firstName . " " . $lastName, $role, $salary);
+    }
+    $stmt->close();
 
   // if the page was posted to
   if (isset($_POST['empId']) && isset($_POST['salary']) && $_SESSION['access'] == 1) {
@@ -95,6 +95,10 @@ if ($stmt = $mysqli->prepare("SELECT employeeId, firstName, lastName, role, sala
     }
   }
 }
+echo <<<EOT
+</tbody>
+</table>
+EOT;
 
 $mysqli->close();
 ?>

--- a/patient/family-member-home.php
+++ b/patient/family-member-home.php
@@ -21,4 +21,37 @@ echo <<<EOT
 <input type=submit value=Logout>
 </form>
 EOT;
+
+echo <<<EOT
+<form action="family-member-home.php" method="post">
+<label for="rosterDate">Date</label>
+<input type="text" name="rosterDate">
+
+<label for="familyCode">Family Code</label>
+<input type="text" name="familyCode">
+
+<label for="patientId">Patient ID</label>
+<input type="text" name="patientId">
+EOT;
+
+if (isset($_POST['rosterDate']) && isset($_POST['familyCode']) && isset($_POST['patientId'])) {
+  echo <<<EOT
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Doctor's Name</th>
+        <th scope="col">Doctor's Appointment</th>
+        <th scope="col">Caregiver Name</th>
+        <th scope="col">Morning Medicine</th>
+        <th scope="col">Afternoon Medicine</th>
+        <th scope="col">Night Medicine</th>
+        <th scope="col">Breakfast</th>
+        <th scope="col">Lunch</th>
+        <th scope="col">Dinner</th>
+      </tr>
+    </thead>
+    <tbody>
+    EOT;
+}
+$mysqli->close();
 ?>

--- a/patient/family-member-home.php
+++ b/patient/family-member-home.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+
+// if they are not a supervisor or admin
+if ($_SESSION['access'] != 6) {
+  header("Location: ../home.html");
+  exit;
+}
+// create mysqli object
+$mysqli = new mysqli('localhost', 'root', '', 'retirement');
+
+/* check connection */
+if (mysqli_connect_errno()) {
+    printf("Connect failed: %s\n", mysqli_connect_error());
+    exit();
+}
+
+// logout button
+echo <<<EOT
+<form action="../authentication/logout.php" method="get">
+<input type=submit value=Logout>
+</form>
+EOT;
+?>


### PR DESCRIPTION
These commits do two things.
Create the Family Member Page
- Family members can use their family code and patient ID to look at a patient's checkboxes on a certain date.

Employee List move around
- The search query on the employee list page was moved above the actual table, since it would be lost in thousands of employees.